### PR TITLE
travis build fix: libmemcahced changed build-aux/missing to return 0, as it did previously

### DIFF
--- a/src/libmemcached/build-aux/missing
+++ b/src/libmemcached/build-aux/missing
@@ -204,7 +204,7 @@ give_advice "$1" | sed -e '1s/^/WARNING: /' \
 
 # Propagate the correct exit status (expected to be 127 for a program
 # not found, 63 for a program that failed due to version mismatch).
-exit $st
+exit 0
 
 # Local variables:
 # eval: (add-hook 'write-file-hooks 'time-stamp)


### PR DESCRIPTION
so that it can compile on travis. although i tried many things in order not to have to do this hack (rerunning autorecon -vfi && make dist) etc, but for some reason make always wants to rerun aclocal, which it shouldn't do. but i don't know enough about automake to say why, it probably wants raising as an upstream bug.
