### PR TITLE
Apply Zefram's patches

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -750,6 +750,7 @@ src/libmemcached/util/string.hpp
 src/libmemcached/version.m4
 src/libmemcached/win32/include.am
 src/libmemcached/win32/wrappers.h
+src/libmemcached.patch
 src/README
 t/00-load.t
 t/01-import.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -212,6 +212,7 @@ sub build_libmemcached {
         if $opt_pg;
     if ($is_developer) {    # XXX make a Makefile.PL argument/option
     }
+    $configure_args .= ' --disable-jobserver';
     run("cd $lmcd_src && ./configure --prefix=$lmcd_inst $configure_args");
     #run("cd $lmcd_src && make test") if $is_developer; # XXX
     run("cd $lmcd_src && make install");

--- a/libmemcached.pm
+++ b/libmemcached.pm
@@ -9,11 +9,11 @@ Memcached::libmemcached - Thin fast full interface to the libmemcached client AP
 
 =head1 VERSION
 
-Version 1.001800 (with libmemcached-1.0.18 embedded)
+Version 1.001801 (with libmemcached-1.0.18 embedded)
 
 =cut
 
-our $VERSION = '1.001800'; # also alter in pod above
+our $VERSION = '1.001801'; # also alter in pod above
 
 use Carp;
 use base qw(Exporter);

--- a/libmemcached.xs
+++ b/libmemcached.xs
@@ -821,7 +821,7 @@ memcached_flush(Memcached__libmemcached ptr, lmc_expiration expiration=0)
 void
 memcached_quit(Memcached__libmemcached ptr)
 
-char *
+const char *
 memcached_strerror(Memcached__libmemcached ptr, memcached_return rc)
 
 const char *

--- a/src/libmemcached/libmemcached-1.0/memcached.h
+++ b/src/libmemcached/libmemcached-1.0/memcached.h
@@ -43,8 +43,7 @@
 #endif
 
 #ifdef __cplusplus
-#  include <mem_config.h> /* for CINTTYPES_H */
-#  include CINTTYPES_H
+#  include CINTTYPES_H	/* defined in libmemcached/mem_config.h */
 #  include <cstddef>
 #  include <cstdlib>
 #else

--- a/src/libmemcached/libmemcached-1.0/memcached.h
+++ b/src/libmemcached/libmemcached-1.0/memcached.h
@@ -43,7 +43,8 @@
 #endif
 
 #ifdef __cplusplus
-#  include <cinttypes>
+#  include <mem_config.h> /* for CINTTYPES_H */
+#  include CINTTYPES_H
 #  include <cstddef>
 #  include <cstdlib>
 #else

--- a/src/libmemcached/libmemcached-1.0/t/cc_test.cc
+++ b/src/libmemcached/libmemcached-1.0/t/cc_test.cc
@@ -37,6 +37,7 @@
 /*
  * @file @brief C dummy test, aka testing C linking, etc
  */
+#include <mem_config.h>
 
 #include <cstdlib>
 

--- a/typemap
+++ b/typemap
@@ -140,7 +140,7 @@ T_MEMCACHED
             /* setup $arg as a ref to a blessed hash hv */
             lmc_state_st *lmc_state;
             HV *hv = newHV();
-            char *classname = \"${(my $ntt=$ntype)=~s/__/::/g;\$ntt}\";
+            const char *classname = \"${(my $ntt=$ntype)=~s/__/::/g;\$ntt}\";
             /* take (sub)class name to use from class_sv if appropriate */
             if (class_sv && SvOK(class_sv) && sv_derived_from(class_sv, classname))
                 classname = (SvROK(class_sv)) ? sv_reftype(class_sv, 0) : SvPV_nolen(class_sv);


### PR DESCRIPTION
This pull request applies Zefram's patches to un-parallelize the build process, and to suppress const-to-non-const warnings in XS code. I have also included  a change to fix the <tr1/cinttypes> problem, for older compilers that expect the 'tr1/' path. Version number is incremented to 1.001801.